### PR TITLE
Add safe-area bottom inset support for BottomTabBar and layouts

### DIFF
--- a/packages/design-system/src/components/BottomTabBar/BottomTabBar.tsx
+++ b/packages/design-system/src/components/BottomTabBar/BottomTabBar.tsx
@@ -40,7 +40,9 @@ export function BottomTabBar({ tabs, currentPath, onNavigate }: Props) {
         onChange={(_, newValue) => onNavigate(newValue)}
         showLabels
         sx={{
-          height: '48px',
+          height: 'calc(48px + env(safe-area-inset-bottom, 0px))',
+          paddingBottom: 'env(safe-area-inset-bottom, 0px)',
+          boxSizing: 'border-box',
           backgroundColor: '#fff',
           '& .MuiBottomNavigationAction-root': {
             color: 'var(--color-text-primary, #000)',

--- a/services/web-messages-ssr/app/layout.tsx
+++ b/services/web-messages-ssr/app/layout.tsx
@@ -26,7 +26,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
             <CssBaseline />
             <main
               style={{
-                height: 'calc(var(--user-screen-height, 100dvh) - 48px)',
+                height: 'calc(var(--user-screen-height, 100dvh) - 48px - env(safe-area-inset-bottom, 0px))',
                 display: 'flex',
                 flexDirection: 'column',
                 overflow: 'hidden',

--- a/services/web-news-ssr/app/layout.tsx
+++ b/services/web-news-ssr/app/layout.tsx
@@ -36,7 +36,16 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
         <AppRouterCacheProvider>
           <ThemeProvider theme={theme}>
             <CssBaseline />
-            <main style={{ flex: 1, paddingBottom: '48px', display: 'flex', flexDirection: 'column' }}>{children}</main>
+            <main
+              style={{
+                flex: 1,
+                paddingBottom: 'calc(48px + env(safe-area-inset-bottom, 0px))',
+                display: 'flex',
+                flexDirection: 'column',
+              }}
+            >
+              {children}
+            </main>
             <MainAppBottomTabBar homePath="/news" unreadMessagesCount={unreadMessagesCount} />
           </ThemeProvider>
         </AppRouterCacheProvider>

--- a/services/web-schedule-ssr/app/layout.tsx
+++ b/services/web-schedule-ssr/app/layout.tsx
@@ -36,7 +36,16 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
         <AppRouterCacheProvider>
           <ThemeProvider theme={theme}>
             <CssBaseline />
-            <main style={{ flex: 1, paddingBottom: '48px', display: 'flex', flexDirection: 'column' }}>{children}</main>
+            <main
+              style={{
+                flex: 1,
+                paddingBottom: 'calc(48px + env(safe-area-inset-bottom, 0px))',
+                display: 'flex',
+                flexDirection: 'column',
+              }}
+            >
+              {children}
+            </main>
             <MainAppBottomTabBar homePath="/calendar" unreadMessagesCount={unreadMessagesCount} />
           </ThemeProvider>
         </AppRouterCacheProvider>


### PR DESCRIPTION
### Motivation
- Prevent the bottom tab bar and page content from overlapping system gesture/navigation areas on devices with a bottom safe area.
- Ensure all pages that render the shared bottom tab bar reserve the same safe-area-aware space so content stays visible above system controls.

### Description
- Updated `packages/design-system/src/components/BottomTabBar/BottomTabBar.tsx` to use `height: calc(48px + env(safe-area-inset-bottom, 0px))`, add `paddingBottom: env(safe-area-inset-bottom, 0px)`, and set `boxSizing: 'border-box'` so the tab bar includes the safe-area inset.
- Updated `services/web-news-ssr/app/layout.tsx` and `services/web-schedule-ssr/app/layout.tsx` to set `<main>` `paddingBottom: calc(48px + env(safe-area-inset-bottom, 0px))` to reserve space for the tab bar plus safe area.
- Updated `services/web-messages-ssr/app/layout.tsx` to subtract `env(safe-area-inset-bottom, 0px)` from the `<main>` height calculation so the layout accounts for the safe area.

### Testing
- Ran `pnpm -w exec biome check packages/design-system/src/components/BottomTabBar/BottomTabBar.tsx services/web-news-ssr/app/layout.tsx services/web-schedule-ssr/app/layout.tsx services/web-messages-ssr/app/layout.tsx` and the check completed successfully with no fixes applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebb254d0b88326a7d4a9dc6fe7b868)